### PR TITLE
feat: add flag to optionally disable uptime threshold filtering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ FAUCET_PK=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 # BALANCE_THRESHOLD=0.1 # minimum validator P-chain balance in AVAX to trigger refuel
 # REFILL_AMOUNT=0.2 # amount of AVAX to refuel when triggered
 # UPTIME_THRESHOLD=80 # minimum validator uptime % to be considered for refuel
+# USE_UPTIME_FILTER=true # use validator uptime filter
 
 # DELAY_PCHAIN_TX=10000 # timeout in ms after any P-Chain tx
 # DELAY_VALIDATOR=1000 # timeout in ms after processing a validator

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+*.log
 
 # env files
 .env

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ UPTIME_API=https://testnet.nodes.onbeam.com/api/uptime # uptime api endpoint of 
 BALANCE_THRESHOLD=0.1 # minimum validator P-chain balance in AVAX to trigger refuel
 REFILL_AMOUNT=0.2 # amount of AVAX to refuel when triggered
 UPTIME_THRESHOLD=80 # minimum validator uptime % to be considered for refuel
+USE_UPTIME_FILTER=true # use validator uptime filter
 
 DELAY_PCHAIN_TX=10000 # timeout in ms after every P-Chain tx
 DELAY_VALIDATOR=1000 # timeout in ms after processing a validator

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ const beamMainnet: ChainConfig = {
   validatorBalanceTopUp: Number(process.env.REFILL_AMOUNT) || 0.2,
   validatorDelay: Number(process.env.DELAY_VALIDATOR) || 1000,
   validatorUptimeThresholdPercent: Number(process.env.UPTIME_THRESHOLD) || 80,
+  useValidatorUptimeFilter: process.env.USE_UPTIME_FILTER?.toLowerCase() !== 'false',
   blacklistedValidatorIds,
 
   faucetBalanceThresholdWarn: Number(process.env.FAUCET_BALANCE_WARN) || 10,

--- a/src/refuel.ts
+++ b/src/refuel.ts
@@ -75,7 +75,10 @@ export const handleValidator = async (validation: ValidationInfo) => {
       `\nProcessing validator ${validator.nodeID} (validation ID ${validationID})...\n- balance: ${fromPChainWei(validator.balance)} AVAX.`,
     );
 
-    if (uptimePercentage < config.validatorUptimeThresholdPercent) {
+    if (
+      config.useValidatorUptimeFilter &&
+      uptimePercentage < config.validatorUptimeThresholdPercent
+    ) {
       console.info(
         `- skipping inactive validator ${nodeID}, uptime of ${uptimePercentage.toFixed(1)}% is < ${config.validatorUptimeThresholdPercent}%.`,
       );

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export type ChainConfig = {
   blacklistedValidatorIds: string[];
   faucetBalanceThresholdWarn: number;
   faucetBalanceThresholdError: number;
+  useValidatorUptimeFilter: boolean;
 };
 
 export type ValidationInfo = {


### PR DESCRIPTION
Skip filtering validators by uptime when USE_UPTIME_FILTER=false.
This makes the behavior explicit and allows topping up validators with 0% uptime (e.g. newly registered or recovering nodes).

Default behavior remains unchanged.